### PR TITLE
add: fix for utf-8 support in input files

### DIFF
--- a/bin/xunitmerge
+++ b/bin/xunitmerge
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser(
 parser.add_argument(
     'report',
     nargs='+',
-    type=argparse.FileType('r'),
+    type=argparse.FileType('r', encoding='utf-8'),
     help='Path of XUnit xml report. Multiple can be provided.',
 )
 parser.add_argument(


### PR DESCRIPTION
Allow input files with utf-8 encoding.  Seeing the following without this patch and a utf-8 char in the XML input.

```
00:13:46.300  + xunitmerge junit-premerge-0.xml junit-premerge-1.xml junit-premerge-2.xml junit-premerge-3.xml junit.xml
00:13:46.300  Traceback (most recent call last):
00:13:46.300    File "/usr/local/bin/xunitmerge", line 26, in <module>
00:13:46.300      merge_xunit(args.report, args.output)
00:13:46.300    File "/usr/local/lib/python3.6/dist-packages/xunitmerge/xmerge.py", line 120, in merge_xunit
00:13:46.300      trees.append(etree.parse(f))
00:13:46.300    File "/usr/lib/python3.6/xml/etree/ElementTree.py", line 1196, in parse
00:13:46.300      tree.parse(source, parser)
00:13:46.300    File "/usr/lib/python3.6/xml/etree/ElementTree.py", line 597, in parse
00:13:46.300      self._root = parser._parse_whole(source)
00:13:46.300    File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
00:13:46.300      return codecs.ascii_decode(input, self.errors)[0]
00:13:46.300  UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 3636: ordinal not in range(128)
```