### PR TITLE
Update xmerge.py

### DIFF
--- a/xunitmerge/xmerge.py
+++ b/xunitmerge/xmerge.py
@@ -61,11 +61,21 @@ def patch_etree_cname(etree):
             )
             attrs = ' ' + attrs if attrs else ''
             text = CNAME_PATTERN.format(elem.text)
+                        text = CNAME_PATTERN.format(elem.text)
+            if isinstance(text, bytes):
+                text = text.decode('utf-8').strip()
+
+            if isinstance(elem.tag, bytes):
+                elem.tag = elem.tag.decode('utf-8').strip()
+
+            if isinstance(attrs, bytes):
+                attrs = attrs.decode('utf-8').strip()
+                
             write(TAG_PATTERN.format(
                 tag=elem.tag,
                 attrs=attrs,
                 text=text
-            ).encode('utf-8'))
+            ))
         else:
             original_serialize(write, elem, *args, **kwargs)
 


### PR DESCRIPTION
### Summary 

Encountered the following error as we moved to python 3.x from python 2.7, where bytes is a newly supported datatype and requires explicit handling since python 3.x. Tested and Verified the fix and now submitting it for review.


### Error Traceback 

```
Traceback (most recent call last):
  File "/users/jenkins/workspace/cyglass-analytics-ng-checkin-status-check/.venv/bin/xunitmerge", line 26, in <module>
    merge_xunit(args.report, args.output)
  File "/users/jenkins/workspace/cyglass-analytics-ng-checkin-status-check/.venv/lib/python3.8/site-packages/xunitmerge/xmerge.py", line 130, in merge_xunit
    merged.write(output, encoding='utf-8', xml_declaration=True)
  File "/usr/local/lib/python3.8/xml/etree/ElementTree.py", line 772, in write
    serialize(write, self._root, qnames, namespaces,
  File "/users/jenkins/workspace/cyglass-analytics-ng-checkin-status-check/.venv/lib/python3.8/site-packages/xunitmerge/xmerge.py", line 70, in _serialize_xml
    original_serialize(write, elem, *args, **kwargs)
  File "/usr/local/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/users/jenkins/workspace/cyglass-analytics-ng-checkin-status-check/.venv/lib/python3.8/site-packages/xunitmerge/xmerge.py", line 70, in _serialize_xml
    original_serialize(write, elem, *args, **kwargs)
  File "/usr/local/lib/python3.8/xml/etree/ElementTree.py", line 937, in _serialize_xml
    _serialize_xml(write, e, qnames, None,
  File "/users/jenkins/workspace/cyglass-analytics-ng-checkin-status-check/.venv/lib/python3.8/site-packages/xunitmerge/xmerge.py", line 64, in _serialize_xml
    write(TAG_PATTERN.format(
TypeError: write() argument must be str, not bytes
Cleaning up Virtual Environment
```



## Notes 
### There is an open [PR](https://github.com/miki725/xunitmerge/pull/9/files) with a proposed fix that does not work. See details below.

```
write(TAG_PATTERN.format(
                tag=elem.tag,
                attrs=attrs,
                text=text
            ))
```

to be changed to 

```
write(TAG_PATTERN.format(
                tag=elem.tag,
                attrs=attrs,
                text=text
            ).encode('utf-8')))

```
The above fix does not work since anything that is already in bytes needs to be decoded and not encoded. 


However, changing the encode to decode (see below ) does not work either.
```
write(TAG_PATTERN.format(
                tag=elem.tag,
                attrs=attrs,
                text=text
            ).decode('utf-8')))

```

### The working solution is to ensure all the arguments are string compatible when they exist as bytes.



The fix is to tackle the arguments passed to write to be string if they are in bytes.